### PR TITLE
[Bugfix] Fix character encoding issue 

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2639,6 +2639,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // NOTE: cmap can be a sparse array, so use forEach instead of for(;;)
           // to iterate over all keys.
           cmap.forEach(function(charCode, token) {
+            if (typeof token === "number") {
+              map[charCode] = String.fromCodePoint(token);
+              return;
+            }
             var str = [];
             for (var k = 0; k < token.length; k += 2) {
               var w1 = (token.charCodeAt(k) << 8) | token.charCodeAt(k + 1);


### PR DESCRIPTION
<!--
  Before creating this PR:

  1. Set title of PR:
      Use one of the following tags
      [Feature] A new feature
      [Bugfix] A fix
      [Misc] A miscellaneous change

  2. If this is a WIP, add the 🚧 emoji at the beginning, and open a DRAFT PR.
     See: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

### Description

[Trello](https://trello.com/c/PpFeSdds/2348-text-encoding-is-incorrect?filter=)
To fix this issue, I updated the code based on what was change [in this PR](https://github.com/mozilla/pdf.js/pull/14041) for fixing the same issue. 

### To verify

[https://ychen-hosted-envs.web.app/pdfjs-encoding/](https://ychen-hosted-envs.web.app/pdfjs-encoding/)

Steps the above demo was created (and I hope they are correct):
1. Copy the changed files from this repo into webviewer repo  `src/pdfjs/src/src` & replace the files there
2. npm run build-pdfjs-workers
3. npm run build-pdfjs
4. npm run host-env-build

<!-- Describe how a reviewer could verify if your code works. -->

### API change discussion link

No changes to API

### UI/UX change discussion link

No changes to UIUX

### Effect on pdf.js express

This fixes a pdfjs specific issue

### Checklist

<!--
  If something is not applicable you can just check the box
  Fill it in with an "x" if it's complete e.g. [x]
-->

- [x] Added jsdoc comments for newly exposed APIs
- [x] Added @method in the jsdoc comments for newly exposed functions, e.g. `@method Core.AnnotationManager#exportAnnotations`
- [x] Double checked spelling and grammar in jsdoc comments
- [x] Used square brackets around property names where it is necessary (Object properties from user provided parameters, properties that are defined with quotes in Object.defineProperties)
- [x] When using innerHTML or dangerouslySetInnerHTML double checked they are actually needed and if they are needed, that user data is sanitized
- [x] Tests are not available to pdfjs express
- [x] If PR contains any UI, visual updates, generate a link (`npm run host-env`) and send it over Xodo to Carolyn Chen (@caroly) or Joshua Sun (@joshuasun) for review. 

### Related issues

pdfjs express community topic [link](https://pdfjs.community/t/wrong-encoding-inside-pdf/1236/3)

